### PR TITLE
add name of feed to cached content

### DIFF
--- a/twigfeeds.php
+++ b/twigfeeds.php
@@ -151,6 +151,8 @@ class TwigFeedsPlugin extends Plugin
 								}
 								
 								if ($pluginsobject['cache']) {
+									/* Add custom name to feed before saving */
+									$feed_items[$name]['name'] = $name;
 									/* Save results */
 									$file = File::instance($cache_path . '' . $filename);
 									$file->save(json_encode($feed_items[$name], JSON_PRETTY_PRINT));
@@ -158,7 +160,13 @@ class TwigFeedsPlugin extends Plugin
 							} else {
 								$file = File::instance($cache_path . '' . $filename);
 								$data = json_decode($file->content());
-								$feed_items[$data->title] = $data;
+								if ($data->name) {
+									$name = $data->name;
+								}
+								else {
+									$name = $data->title;
+								}
+								$feed_items[$name] = $data;
 								if ($pluginsobject['debug'] && $this->config->get('system')['debugger']['enabled']) {
 									$this->grav['debugger']->addMessage(array('state' =>'cached', 'type' => gettype($data), 'action' => 'add to feed_items: : ' . $filename, $data));
 									$this->grav['log']->debug('Twig Feeds: ' . $filename . ', state: cached, type: ' . gettype($data) . ', action: add to feed_items');


### PR DESCRIPTION
Main problem was that I wasn't able to still use `twig_feeds.my_custom_name` to get only `my_custom_name` feed. 

Add robustness to code if the (external) blog suddenly changes its title­.